### PR TITLE
Avoid eval-parse when loading orgDb

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -20,14 +20,13 @@
 ##' @param OrgDb OrgDb object or OrgDb name
 ##' @return OrgDb object
 ##' @importFrom methods is
+##' @importFrom utils getFromNamespace 
 ##' @export
 ##' @author Guangchuang Yu
 load_OrgDb <- function(OrgDb) {
-    if (is(OrgDb, "character")) {
-        require(OrgDb, character.only = TRUE)
-        OrgDb <- eval(parse(text=OrgDb))
-    }
-    return(OrgDb)
+     if (is(OrgDb, "character")) {
+    utils::getFromNamespace(OrgDb, OrgDb)
+  }
 }
 
 ##' @importFrom GO.db GOMFANCESTOR


### PR DESCRIPTION
Hello,

This PR aims to avoid using `require` and `eval(parse(...))` when loading an `orgDb`. These have security [implications](https://stackoverflow.com/questions/13649979/what-specifically-are-the-dangers-of-evalparse). The issues with require are shown [here](https://stackoverflow.com/questions/5595512/what-is-the-difference-between-require-and-library).

Thanks,

NelsonGon